### PR TITLE
feat: use pretty-ms and Intl to parse and format dates and milliseconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "got": "^11.8.0",
     "iso8601-duration": "^1.2.0",
     "opusscript": "^0.0.7",
+    "pretty-ms": "^7.0.1",
     "tslib": "^2.0.3",
     "winston": "^3.3.3",
     "ytdl-core": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ignorePatterns": "dist/*"
   },
   "dependencies": {
-    "date-fns": "^2.16.1",
     "discord.js": "^12.4.1",
     "dotenv": "^8.2.0",
     "entities": "^2.1.0",

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,5 +1,18 @@
 import winston from "winston";
-import { format } from "date-fns";
+
+// @ts-expect-error ignore
+const dateFormat = Intl.DateTimeFormat("en", { dateStyle: "short", timeStyle: "medium", hour12: false });
+
+function formatDateForLogFile(date?: number | Date): string {
+    const data = dateFormat.formatToParts(date);
+    return `<year>-<month>-<day>-<hour>-<minute>-<second>`
+        .replace(/<year>/g, data.find(({ type }) => type === "year")!.value)
+        .replace(/<month>/g, data.find(({ type }) => type === "month")!.value)
+        .replace(/<day>/g, data.find(({ type }) => type === "day")!.value)
+        .replace(/<hour>/g, data.find(({ type }) => type === "hour")!.value)
+        .replace(/<minute>/g, data.find(({ type }) => type === "minute")!.value)
+        .replace(/<second>/g, data.find(({ type }) => type === "second")!.value);
+}
 
 export function createLogger(serviceName: string, debug = false): winston.Logger {
     const logger = winston.createLogger({
@@ -9,7 +22,7 @@ export function createLogger(serviceName: string, debug = false): winston.Logger
         format: winston.format.combine(
             winston.format.printf(info => {
                 const { level, message, stack } = info;
-                const prefix = `[${format(Date.now(), "yyyy-MM-dd HH:mm:ss (x)")}] [${level}]`;
+                const prefix = `[${dateFormat.format(Date.now())}] [${level}]`;
                 if (["error", "crit"].includes(level)) return `${prefix}: ${stack}`;
                 return `${prefix}: ${message}`;
             })
@@ -24,8 +37,8 @@ export function createLogger(serviceName: string, debug = false): winston.Logger
             warn: 2
         },
         transports: [
-            new winston.transports.File({ filename: `logs/${serviceName}/error-${format(Date.now(), "yyyy-MM-dd-HH-mm-ss")}.log`, level: "error" }),
-            new winston.transports.File({ filename: `logs/${serviceName}/logs-${format(Date.now(), "yyyy-MM-dd-HH-mm-ss")}.log` })
+            new winston.transports.File({ filename: `logs/${serviceName}/error-${formatDateForLogFile(Date.now())}.log`, level: "error" }),
+            new winston.transports.File({ filename: `logs/${serviceName}/logs-${formatDateForLogFile(Date.now())}.log` })
         ]
     });
     logger.add(new winston.transports.Console({
@@ -33,7 +46,7 @@ export function createLogger(serviceName: string, debug = false): winston.Logger
         format: winston.format.combine(
             winston.format.printf(info => {
                 const { level, message, stack } = info;
-                const prefix = `[${format(Date.now(), "yyyy-MM-dd HH:mm:ss (x)")}] [${level}]`;
+                const prefix = `[${dateFormat.format(Date.now())}] [${level}]`;
                 if (["error", "alert"].includes(level)) return `${prefix}: ${stack}`;
                 return `${prefix}: ${message}`;
             }),

--- a/src/utils/YoutubeAPI/types/index.d.ts
+++ b/src/utils/YoutubeAPI/types/index.d.ts
@@ -66,7 +66,7 @@ export interface IVideo {
         url: string;
     };
     thumbnails: IThumbnails;
-    duration: Duration | null; // NOTE: Parse this with date-fns (https://github.com/date-fns/date-fns/discussions/2064)
+    duration: Duration | null;
     status: {
         uploadStatus: uploadStatus;
         failureReason: failureReason;

--- a/src/utils/formatMS.ts
+++ b/src/utils/formatMS.ts
@@ -1,6 +1,9 @@
-import { formatDuration, intervalToDuration } from "date-fns";
+import prettyMilliseconds from "pretty-ms";
 
 export function formatMS(ms: number): string {
     if (isNaN(ms)) throw new Error("value is not a number.");
-    return formatDuration(intervalToDuration({ start: 0, end: ms }));
+    return prettyMilliseconds(ms, {
+        verbose: true,
+        compact: true
+    });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1496,6 +1496,11 @@ parse-cache-control@^1.0.1:
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
   integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -1520,6 +1525,13 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+pretty-ms@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 prism-media@^1.2.2:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,11 +566,6 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-date-fns@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
-  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
-
 debug@4, debug@^4.0.1, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"


### PR DESCRIPTION
[date-fns](https://npmjs.com/package/date-fns) is huge, and jukebox didn't use it that much it's only used to format milliseconds and date for a log file which can be done with pretty-ms and [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for parsing and formatting dates