### PR TITLE
fix(AboutCommand): Fix invalid memory usage

### DIFF
--- a/src/commands/AboutCommand.ts
+++ b/src/commands/AboutCommand.ts
@@ -27,9 +27,9 @@ YT Data Strategy    :: ${await this.client.config.YouTubeDataRetrievingStrategy 
 Platform            :: ${process.platform}
 Arch                :: ${process.arch}
 OS Uptime           :: ${this.client.util.formatMS(osUptime() * 1000)}
-Memory (RSS)        :: ${this.client.util.bytesToSize(await this.client.util.getTotalMemory("rss"))} 
-Memory (Heap Total) :: ${this.client.util.bytesToSize(await this.client.util.getTotalMemory("heapTotal"))}
-Memory (Heap Used)  :: ${this.client.util.bytesToSize(await this.client.util.getTotalMemory("heapUsed"))}
+Memory (RSS)        :: ${this.client.util.bytesToSize(process.memoryUsage().rss)} 
+Memory (Heap Total) :: ${this.client.util.bytesToSize(process.memoryUsage().heapTotal)}
+Memory (Heap Used)  :: ${this.client.util.bytesToSize(process.memoryUsage().heapUsed)}
 Process Uptime      :: ${this.client.util.formatMS(process.uptime() * 1000)}
 Bot Uptime          :: ${this.client.util.formatMS(this.client.uptime!)}
 

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -84,11 +84,6 @@ export class Util {
             .then(data => data.reduce((a, b) => a + b));
     }
 
-    public async getTotalMemory(type: keyof NodeJS.MemoryUsage): Promise<number> {
-        if (!this.client.shard) return process.memoryUsage()[type];
-        return this.client.shard.broadcastEval(`process.memoryUsage()["${type}"]`).then(data => data.reduce((a, b) => a + b));
-    }
-
     public hastebin(text: string): Promise<string> {
         return new Promise((resolve, reject) => {
             const req = request({ hostname: "bin.hzmi.xyz", path: "/documents", method: "POST", minVersion: "TLSv1.3" }, res => {


### PR DESCRIPTION
This is caused by Util#getTotalMemory that we don't need anymore, because we recently switched to worker sharding in 6c6146096244dd8ae1cfc6e90229554d9801f54f

Fixes #616
