### PR TITLE
feat(PlayCommand): Throw helpful messages instead of The operation was aborted in entersState

### DIFF
--- a/src/commands/PlayCommand.ts
+++ b/src/commands/PlayCommand.ts
@@ -234,7 +234,7 @@ export class PlayCommand extends BaseCommand {
         serverQueue.connection?.subscribe(serverQueue.currentPlayer);
 
         // Wait for 15 seconds for the connection to be ready.
-        entersState(serverQueue.connection!, VoiceConnectionStatus.Disconnected, 15 * 1000)
+        entersState(serverQueue.connection!, VoiceConnectionStatus.Ready, 15 * 1000)
             .then(() => serverQueue.currentPlayer!.play(playerResource))
             .catch(e => {
                 if (e.message === "The operation was aborted") e.message = "Could not establish a voice connection within 15 seconds.";


### PR DESCRIPTION
fixes #630 