### PR TITLE
chore(deps): Remove not used dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true # TODO: Remove this when prism-media updates it's peerDependencies (currently peerdependency @discordjs/opus conflicts) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "entities": "^3.0.1",
         "ffmpeg-static": "^4.4.0",
         "opusscript": "^0.0.8",
-        "parse-ms": "^2.1.0",
         "pretty-ms": "^7.0.1",
+        "prism-media": "^1.3.2",
         "tslib": "^2.3.1",
         "winston": "^3.3.3",
         "ytdl-core": "^4.9.1",
@@ -26,8 +26,6 @@
       "devDependencies": {
         "@hazmi35/eslint-config": "^5.0.0",
         "@types/node": "^16.7.10",
-        "@types/node-fetch": "^3.0.3",
-        "@types/semver": "^7.3.8",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
         "eslint": "^7.32.0",
@@ -432,22 +430,6 @@
       "version": "16.7.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
       "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "*"
-      }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
-      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -3320,8 +3302,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hazmi35/eslint-config/-/eslint-config-5.0.0.tgz",
       "integrity": "sha512-5sPv0IKyeol1jDGncqIr7wtHofYCpsRrduERVvKyCZuwVwPx/6cko5/VfU3mPhSKVesuPqY+hLPvg81tirnz9g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -3410,21 +3391,6 @@
       "version": "16.7.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
       "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA=="
-    },
-    "@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "*"
-      }
-    },
-    "@types/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
-      "dev": true
     },
     "@types/ws": {
       "version": "7.4.7",
@@ -3532,8 +3498,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.1.1",
@@ -4845,8 +4810,7 @@
     "prism-media": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.2.tgz",
-      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g==",
-      "requires": {}
+      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -5355,8 +5319,7 @@
     "ws": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "requires": {}
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "entities": "^3.0.1",
     "ffmpeg-static": "^4.4.0",
     "opusscript": "^0.0.8",
-    "parse-ms": "^2.1.0",
     "pretty-ms": "^7.0.1",
+    "prism-media": "^1.3.2",
     "tslib": "^2.3.1",
     "winston": "^3.3.3",
     "ytdl-core": "^4.9.1",
@@ -44,8 +44,6 @@
   "devDependencies": {
     "@hazmi35/eslint-config": "^5.0.0",
     "@types/node": "^16.7.10",
-    "@types/node-fetch": "^3.0.3",
-    "@types/semver": "^7.3.8",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
* This includes parse-ms, @types/node-fetch and @types/semver
* Not that parse-ms is still installed because it's a dependency of pretty-ms, but it stills nice to not explicitly list it in package.json
* List prism-media as dependencies in package.json
