### PR TITLE
fix(sharding): Fix ShardingManager#spawn error for Util#fetchRecommendedShards

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,4 +31,4 @@ manager.on("shardCreate", shard => {
         log.info(`[ShardManager] Shard #${shard.id} Reconnected.`);
     });
     if (manager.shards.size === manager.totalShards) log.info("[ShardManager] All shards spawned successfully.");
-}).spawn().catch(e => log.error("SHARD_SPAWN_ERR: ", e));
+}).spawn().catch(e => log.error("SHARD_SPAWN_ERR:", e.status ? `Error while fetching recommended shards: ${e.status}, ${e.statusText}` : e));


### PR DESCRIPTION
If the totalShards value is auto, discord.js fetches recommended totalShards with Util#fetchRecommendedShards
If it fails, it throws node-fetch response data, instead of an Error instance
