### PR TITLE
fix(ServerQueue): Pass playing property to flatten ServerQueue

### DIFF
--- a/src/structures/ServerQueue.ts
+++ b/src/structures/ServerQueue.ts
@@ -117,8 +117,8 @@ export class ServerQueue {
             });
     }
 
-    public toJSON(): any {
-        return Util.flatten(this);
+    public flatten(): any {
+        return Object.assign(Util.flatten(this), { playing: this.playing });
     }
 
     public get volume(): number {

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -59,7 +59,7 @@ export class Util {
             users: (client: Client) => client.users.cache,
             channels: (client: Client) => client.channels.cache,
             guilds: (client: Client) => client.guilds.cache,
-            queues: (client: Client) => client.queue.mapValues(v => v.toJSON())
+            queues: (client: Client) => client.queue.mapValues(v => v.flatten())
         };
 
         /*


### PR DESCRIPTION
Flatten ServerQueue is used by Util#getResource because discord.js ShardClientUtil#broadcastEval won't interact well with Circular.
And because flattening ServerQueue uses discord.js Util#flatten, and with that, we can't access any getter with the flatten Object.
The workarounds is by using Object.assign(flattenedObject, { someProperty: originalObject.someProperty }
This would fix #743
