### PR TITLE
fix(AboutCommand): Rename youtube-dl to yt-dlp version

### DIFF
--- a/src/commands/AboutCommand.ts
+++ b/src/commands/AboutCommand.ts
@@ -35,7 +35,7 @@ Bot Uptime          :: ${this.client.util.formatMS(this.client.uptime!)}
 Node.js version     :: ${process.version}
 Discord.js version  :: v${version}
 FFmpeg version      :: v${this.client.util.getFFmpegVersion().replaceAll("_", "-")}
-youtube-dl          :: ${process.env.YOUTUBE_DL_FILENAME!} ${(await youtube("--version") as any).toString()}
+yt-dlp version      :: ${(await youtube("--version") as any).toString()}
 Opus Encoder        :: ${(await this.client.util.getOpusEncoderName()).replaceAll("_", "-")}
 Bot Version         :: v${(await this.client.util.getPackageJSON()).version}
 


### PR DESCRIPTION
Jukebox used youtube-dl-exec, but it uses the yt-dlp (a youtube-dl fork) binary.
Jukebox will not support any modifications to it's dependencies
You could probably switch to original youtube-dl by changing some settings in .npmrc and changing the binary filename on Jukebox#ytdl
