### PR TITLE
fix(VoiceStateUpdateEvent): Don't return on deleted voice channel

### DIFF
--- a/src/events/VoiceStateUpdateEvent.ts
+++ b/src/events/VoiceStateUpdateEvent.ts
@@ -37,9 +37,6 @@ export class VoiceStateUpdateEvent extends BaseEvent {
             }
         }
 
-        // Don't do anything if voice channel is deleted.
-        if (newVC === null) return undefined;
-
         if (newState.mute !== oldState.mute || newState.deaf !== oldState.deaf) return undefined; // TODO: Handle all listeners deaf & bot muted event?
 
         // Handle when the bot is moved to another voice channel


### PR DESCRIPTION
Do not return on deleted voice channel, as the timeout will be cleared by voice channel kicked handler.
