### PR TITLE
fix(Track): Remove string from yt-dlp flags

### DIFF
--- a/src/structures/Track.ts
+++ b/src/structures/Track.ts
@@ -26,11 +26,11 @@ export class Track {
             const process = this.queue.client.ytdl.raw(
                 this.metadata.url,
                 {
+                    ffmpegLocation: `${ffmpegStatic}`,
                     format: this.resourceFormat,
-                    ffmpegLocation: `"${ffmpegStatic}"`,
+                    limitRate: "800K",
                     output: "-",
-                    quiet: true,
-                    limitRate: "800K"
+                    quiet: true
                 },
                 { stdio: ["ignore", "pipe", "ignore"] }
             );


### PR DESCRIPTION
execa handles spaces in flags, so we don't need to add string manually or it would break
this causes yt-dlp fails to spawn ffmpeg.
