### PR TITLE
deletion of example configurations in .env.schema

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -3,112 +3,112 @@
 # Secret things
 
 # Your Discord bot's token
-SECRET_DISCORD_TOKEN=Njk1NjY0ODU4NDA1Nzk3ODg4.dQw4w9WgXcQ.TmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA
+SECRET_DISCORD_TOKEN=
 
 # Base config
 
 # Your bot's prefix
-CONFIG_PREFIX="jukebox "
+CONFIG_PREFIX=
 
 # A Discord ID(s), use comma if you want to add more than 1 owner
 # NOTE: DO NOT ADD SOMEONE ELSE ID THAT YOU DON'T TRUST
-CONFIG_OWNERS=290159952784392202
+CONFIG_OWNERS=
 
 # Total shards to spawn, use "auto" or a number
 # DEFAULT: AUTO
-CONFIG_TOTALSHARDS=auto
+CONFIG_TOTALSHARDS=
 
 # Should logging use debug level? Please note that this is not recommended in production
 # INPUT: yes or no
 # DEFAULT no
-CONFIG_DEBUG=no
+CONFIG_DEBUG=
 
 # Whether to cache users to memory
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_CACHE_USERS=no
+CONFIG_CACHE_USERS=
 
 # Queue config
 
 # Whether to allow users to add duplicate of tracks
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_ALLOW_DUPLICATE=no
+CONFIG_ALLOW_DUPLICATE=
 
 # Timeout in seconds before queue is deleted when no one is in the voice channel
 # INPUT: Input should be in seconds
 # DEFAULT: 180 (3 minutes)
-CONFIG_DELETE_QUEUE_TIMEOUT=180
+CONFIG_DELETE_QUEUE_TIMEOUT=
 
 # Play command config
 
 # Select track timeout when searching tracks
 # INPUT: Input should be in seconds
 # DEFAULT: 20 Seconds
-CONFIG_SELECT_TIMEOUT=20
+CONFIG_SELECT_TIMEOUT=
 
 # Whether to disable selecting tracks on play command, this will automatically selects the first track from search results
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_DISABLE_TRACK_SELECTION=no
+CONFIG_DISABLE_TRACK_SELECTION=
 
 # Maximum tracks to list in track selection (default: 10 max: 15)
 # DEFAULT: 10
 # MAX: 15
-CONFIG_SEARCH_MAX_RESULTS=10
+CONFIG_SEARCH_MAX_RESULTS=
 
 # Volume config
 
 # Enable inline volume feature or not
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_ENABLE_INLINE_VOLUME=no
+CONFIG_ENABLE_INLINE_VOLUME=
 
 # Default volume for music
 # DEFAULT: 100
 # NOTE: CONFIG_ENABLE_INLINE_VOLUME
-CONFIG_DEFAULT_VOLUME=100
+CONFIG_DEFAULT_VOLUME=
 
 # Max volume allowed for music
 # DEFAULT: 100
 # NOTE: CONFIG_ENABLE_INLINE_VOLUME
-CONFIG_MAX_VOLUME=100
+CONFIG_MAX_VOLUME=
 
 # Music cache config
 
 # Whether to download and cache tracks from youtube
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_CACHE_YOUTUBE_DOWNLOADS=no
+CONFIG_CACHE_YOUTUBE_DOWNLOADS=
 
 # Max track length in seconds that are allowed to be cached
 # DEFAULT: 5400 (1 hour 30 minutes)
-CONFIG_CACHE_MAX_LENGTH=5400
+CONFIG_CACHE_MAX_LENGTH=
 
 # Miscellaneous config
 
 # Whether to disable the invite command or not
 # INPUT: yes or no
 # DEFAULT: no
-CONFIG_DISABLE_INVITE_CMD=no
+CONFIG_DISABLE_INVITE_CMD=
 
 # What type of status does the bot use
 # INPUT: playing, listening or watching
 # DEFAULT: listening
-CONFIG_STATUS_TYPE=listening
+CONFIG_STATUS_TYPE=
 
 # What status does the bot display
 # VARIABLES AVAILABLE: guildsCount, usersCount, playingCount, and botPrefix)
 # DEFAULT: "music on {guildsCount} guilds!"
 # NOTE ON {usersCount} VARIABLE: The value will be 0 if CONFIG_CACHE_USERS is not set to yes
-CONFIG_STATUS_ACTIVITY="music on {guildsCount} guilds!"
+CONFIG_STATUS_ACTIVITY=
 
 # i18n config
 
 # Language to be used in Jukebox, uses IETF language tags, for example: en-US, en-GB, id-ID
 # Available languages: Please see the file list in folder src/langs, you can submit your language by contributing to Jukebox project at GitHub.
 # DEFAULT: en-US
-CONFIG_LANGUAGE=en-US
+CONFIG_LANGUAGE=
 
 # Advanced config (DO NOT UNCOMMENT AND FILL IF YOU DON'T KNOW WHAT YOU'RE DOING.)
 # NOTE: Environment variables without the CONFIG_ prefix is recommended to be set globally.
@@ -116,3 +116,4 @@ CONFIG_LANGUAGE=en-US
 
 # FFmpeg location to use, leave commented to use bundled ffmpeg.
 #FFMPEG_BIN=/usr/bin/ffmpeg
+


### PR DESCRIPTION
in the commit 8a77fdf you have copied .env.example in the .env.schema so I deleted the examples in .env.schema