### PR TITLE
feat(Util): Add getUserIDFromMention and fetchUserFromMention

### DIFF
--- a/src/events/MessageCreateEvent.ts
+++ b/src/events/MessageCreateEvent.ts
@@ -10,7 +10,7 @@ export class MessageCreateEvent extends BaseEvent {
 
         if (message.content.toLowerCase().startsWith(this.client.config.prefix)) return this.client.commands.handle(message);
 
-        if ((await this.client.util.getUserFromMention(message.content))?.id === message.client.user?.id) {
+        if (this.client.util.getUserIDFromMention(message.content) === message.client.user!.id) {
             return message.channel.send({
                 embeds: [createEmbed("info", message.client.lang.MESSAGE_EVENT_ON_MENTION(message.client.config.prefix))]
             });

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -173,11 +173,17 @@ export class Util {
         return array;
     }
 
-    public getUserFromMention(mention: string): Promise<User | undefined> {
+    public getUserIDFromMention(mention: string): Snowflake | undefined {
         const matches = (/^<@!?(?<Snowflake>\d+)>$/).exec(mention);
-        if (!matches) return Promise.resolve(undefined);
+        if (!matches) return undefined;
 
-        const id = matches[1];
+        return matches[1];
+    }
+
+    public fetchUserFromMention(mention: string): Promise<User | null> {
+        const id = this.getUserIDFromMention(mention);
+        if (!id) return Promise.resolve(null);
+
         return this.client.users.fetch(id);
     }
 


### PR DESCRIPTION
The getUserFromMention is flawed, and can lead to ratelimits on fetchUser endpoint.
The ratelimit is caused by everyone mentioning someone and the bot fetches that mentioned user.
The truth is: fetching the User from mention is unnecessary.
Because it is used to extract the ID of user in mention in every message and check if it's Bot's User ID
