### PR TITLE
fix(Docker): Fix permissions error in Docker contact

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -34,15 +34,12 @@ FROM hazmi35/node:16-alpine
 LABEL name "Jukebox"
 LABEL maintainer "Hazmi35 <contact@hzmi.xyz>"
 
-# Install python3 (required for youtube-dl/yt-dlp) and create cache and logs directory
+# Install python3 (required for youtube-dl/yt-dlp), ffmpeg and sudo then create cache and logs directory
 # Plus delete user "node" and create user "jukebox"
-RUN apk add --no-cache python3 ffmpeg \
+RUN apk add --no-cache python3 ffmpeg sudo \
     && ln -s /usr/bin/python3 /usr/local/bin/python \
     && mkdir cache && mkdir logs \
     && deluser --remove-home node && addgroup -S jukebox -g 1000 && adduser -S -G jukebox -u 1000 jukebox
-
-# Use user "jukebox"
-USER jukebox
 
 # Tell ffmpeg-static to use system ffmpeg
 ENV FFMPEG_BIN /usr/bin/ffmpeg
@@ -52,9 +49,13 @@ COPY --from=build-stage --chown=jukebox /tmp/build/package.json .
 COPY --from=build-stage --chown=jukebox /tmp/build/package-lock.json .
 COPY --from=build-stage --chown=jukebox /tmp/build/node_modules ./node_modules
 COPY --from=build-stage --chown=jukebox /tmp/build/dist ./dist
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 # Mark cache folder as docker volume
 VOLUME ["/app/cache", "/app/logs"]
+
+# Execute entrypoint
+ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
 
 # Start the app with node
 CMD ["node", "dist/main.js"]

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -28,27 +28,28 @@ FROM hazmi35/node:16
 LABEL name "Jukebox"
 LABEL maintainer "Hazmi35 <contact@hzmi.xyz>"
 
-# Install python3 (required for youtube-dl/yt-dlp) and create cache and logs directory
+# Install python3 (required for youtube-dl/yt-dlp) and sudo then create cache and logs directory
 # Plus delete user "node" and create user "jukebox"
 RUN apt-get update \
-    && apt-get install -y python-is-python3 locales \
+    && apt-get install -y python-is-python3 locales sudo \
     && apt-get autoremove -y \
     && apt-get autoclean -y \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir cache && mkdir logs \
     && userdel -r node && rm -rf /home/node && groupadd -g 1000 jukebox && useradd -u 1000 -g jukebox -m -s /usr/sbin/nologin jukebox
 
-# Use user "jukebox"
-USER jukebox
-
 # Copy needed files
 COPY --from=build-stage --chown=jukebox /tmp/build/package.json .
 COPY --from=build-stage --chown=jukebox /tmp/build/package-lock.json .
 COPY --from=build-stage --chown=jukebox /tmp/build/node_modules ./node_modules
 COPY --from=build-stage --chown=jukebox /tmp/build/dist ./dist
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 # Mark cache folder as docker volume
 VOLUME ["/app/cache", "/app/logs"]
+
+# Execute entrypoint
+ENTRYPOINT ["/bin/sh", "/docker-entrypoint.sh"]
 
 # Start the app with node
 CMD ["node", "dist/main.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Set permissions for volumes
+chown -R jukebox:jukebox /app/logs /app/cache
+
+# Execute Docker's CMD as jukebox user
+exec sudo -E -u jukebox "$@"


### PR DESCRIPTION
In commit 14601ea3729af06824b40df37aab659fc358355a, the container will always use user "jukebox" inside
this would not have a problem if your Linux user UID and GID is 1000
which makes running the container from the user "root" causes permissions error.

This permissions error are caused by Docker Volumes marking it as owned by user "root"
there is no way to mount Docker Volumes as another user than "root" (REF: moby/moby#2259).

The workaround is to run "chmod -R 1000:1000 cache logs" outside the container before running the contianer
but this requires user intervention, which I dislike for Jukebox use-case

The other workaround is use `--user root` in docker run command, or add a `user: root` in docker-compose.yml services.bot property
but still, that requires user intervention

The solution I used is use Docker ENTRYPOINT to change Docker Volumes ownership to user "jukebox"
and then run the Docker CMD as user jukebox.
